### PR TITLE
Remove redundant paragraph from forest-doc.tex

### DIFF
--- a/forest-doc.tex
+++ b/forest-doc.tex
@@ -1621,12 +1621,6 @@ instruction: thus |O3| below means the same as |OOO|.
   \end{forest}
 \end{forestexample}
 
-Note that the order of the wrapper-macro body and the arguments is different for
-\index{handler>process} and \index{wrap $n$ pgfmath args}.  Experience shows that
-\index{handler>process}'s order is easier on the eyes. The example also illustrates that the
-instructions need not be enclosed in braces and that repetition of an argument processor instruction
-can be indicated by appending a number to the instruction: |O3| above is equivalent to |OOO|.
-
 % \begin{forestexample}[index={process,processor>w}]
 %   \begin{forest}
 %     [root,delay={align=center,


### PR DESCRIPTION
Remove paragraph following example 46 that repeats the paragraph preceding the example.